### PR TITLE
Add option to use a managed private attrbiute

### DIFF
--- a/dcv/fields/text.py
+++ b/dcv/fields/text.py
@@ -16,14 +16,19 @@ class TextField(Field):
     def __init__(
         self,
         default: Optional[str] = cast(str, MISSING),
+        optional: bool=False,
+        use_private_attr: bool=False,
         max_length: Optional[int]=None,
         min_length: Optional[int]=None, *,
-        optional: bool=False,
         blank: bool=False,
         regex: str=None,
         trim: str=None
     ):
-        super().__init__(default, optional)
+        super().__init__(
+            default=default,
+            optional=optional,
+            use_private_attr=use_private_attr
+        )
         self.max_length = max_length
         self.min_length = min_length
         self.blank = blank

--- a/t/unit/test_field.py
+++ b/t/unit/test_field.py
@@ -95,3 +95,29 @@ def test_field_default_and_optional_False():
 
     ot = OT()
     assert ot.name == "x"
+
+
+def test_field_use_private_attr():
+    """Base field.
+
+    GIVEN a custom field with a `default` value and `optional` set to False.
+    WHEN a dataclass uses it
+    THEN it should correctly initialize class.
+    """
+    @dataclass
+    class T:
+        name: str = MyField(use_private_attr=True)
+
+    @dataclass
+    class OT:
+        name: str = MyField(use_private_attr=True)
+
+    t = T(name="x")
+    assert t.name == "x"
+    assert t.__dict__["_name"] == "x"
+    assert ("name" in t.__dict__) == False
+
+    ot = OT(name="x")
+    assert ot.name == "x"
+    assert ot.__dict__["_name"] == "x"
+    assert ("name" in ot.__dict__) == False


### PR DESCRIPTION
[feature: base field] closes #5

By default the field validation descriptor now stores
the value in `obj.__dict__['attr_name']` instead of
storing it in a private attribute `_{attr_name}`.

It is now possible to configure the descriptor
to use a managed private attribute.