### PR TITLE
[#9] Add int, float, decimal and complex fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Dataclasses are powerful, but we still need to validate incoming data.
 Validation libraries make you either subclass a 3rd party class or use a schema class.
 **Now, you can easily validate fields in dataclasses by using field-specific validation**.
 
-## ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) This is a work in progress. The only field implemented right now is [`TextField`](https://github.com/rmcomplexity/dataclasses-validation/blob/main/dcv/fields/text.py)
+## ![#f03c15](https://via.placeholder.com/15/f03c15/000000?text=+) This is a work in progress.
+Please check the [project board](https://github.com/rmcomplexity/dataclasses-validation/projects/1) to see pendining tasks in case there isn't a proper release yet.
 
 ## Example:
 
@@ -14,7 +15,7 @@ Validation libraries make you either subclass a 3rd party class or use a schema 
 import logging
 from dataclasses import dataclass, field, asdict
 from typing import Optional
-from dcv.fields import TextField
+from dcv.fields import TextField, IntField
 
 
 logging.basicConfig(level=logging.INFO)
@@ -25,7 +26,11 @@ class User:
     # trailing/leading blank spaces will be removed
     name: str = TextField(min_length=1, trim=" ")
 
+    # A user cannot be born before 1800. Time travelers are not considered here :(.
+    year_of_birth: int = IntField(gt=1800)
+
     # 'last_name' can be None or an empty string.
+    # Optional fields have a default value of None.
     last_name: Optional[str] = TextField(min_length=1, trim=" ", optional=True, blank=True)
 
     # 'opt_out' has a default value of "Yes", uses a regex
@@ -33,7 +38,7 @@ class User:
     opt_out: str = field(default=TextField(default="Yes", regex="(Yes|No)"), init=False)
 
 # Insantiation without any issues
->>> user = User(name="Josué", last_name="Balandrano")
+>>> user = User(name="Josué", last_name="Balandrano", year_of_birth=1985)
 >>> logging.info(user)
 ... INFO:root:User(name="Josué", last_name="Balandrano", opt_out="Yes")
 
@@ -46,8 +51,9 @@ class User:
 ... {'name': 'Josué', 'last_name': 'Balandrano', 'opt_out': 'Yes'}
 
 # We get a ValueError if an invalid value is used on init
->>> User(name = "", last_name="Balandrano")
+>>> User(name = "", last_name="Balandrano", year_of_birth=1755)
 ... ValueError: 'name' cannot be blank.
+>>> User(name = "Josué", last_name="Balandrano", year_of_birth=1775)
 ```
 
 ## Reasoning

--- a/dcv/fields/__init__.py
+++ b/dcv/fields/__init__.py
@@ -1,4 +1,13 @@
 from dcv.fields.abstract import Field, MISSING
 from dcv.fields.text import TextField
+from dcv.fields.number import IntField, FloatField, DecimalField, ComplexField
 
-__all__ = ["TextField", "Field", "MISSING"]
+__all__ = [
+    "MISSING",
+    "Field",
+    "TextField",
+    "IntField",
+    "FloatField",
+    "DecimalField",
+    "ComplexField",
+]

--- a/dcv/fields/number.py
+++ b/dcv/fields/number.py
@@ -6,8 +6,10 @@ class NumberField(Field):
     """Field validation for number values."""
     ERROR_MSGS = {
         "nan": "'{attr_name}' value '{value}' is not a number.",
-        "min": "'{attr_name}' value '{value}' cannot be less than {min}.",
-        "max": "'{attr_name}' value '{value}' cannot be more than {max}.",
+        "gt": "'{attr_name}' value '{value}' must be greater than {limit}.",
+        "lt": "'{attr_name}' value '{value}' must be less than {limit}.",
+        "ge": "'{attr_name}' value '{value}' must be greater than or equals to {limit}.",
+        "le": "'{attr_name}' value '{value}' must be less than or equals to {limit}.",
     }
     TYPE = (int, float, complex, Decimal)
 
@@ -16,18 +18,120 @@ class NumberField(Field):
         default: Union[int, float, complex, Decimal, None] = cast(int, MISSING),
         optional: bool=False,
         use_private_attr: bool=False,
-        max_limit: Union[int, float, complex, Decimal, None] = None,
-        min_limit: Union[int, float, complex, Decimal, None] = None
+        gt: Union[int, float, complex, Decimal, None] = None,
+        lt: Union[int, float, complex, Decimal, None] = None,
+        ge: Union[int, float, complex, Decimal, None] = None,
+        le: Union[int, float, complex, Decimal, None] = None
     ):
         super().__init__(
             default=default,
             optional=optional,
             use_private_attr=use_private_attr
         )
-        self.max_limit = max_limit
-        self.min_limit = min_limit
+        self.gt = gt
+        self.lt = lt
+        self.ge = ge
+        self.le = le
 
     def validate(self, value: Union[int, float, complex, Decimal, None]) -> None:
         self._validate_optional(value)
 
         self._check_type(value)
+
+        if self.gt is not None:
+            self._validate_gt(value, self.gt)
+
+        if self.lt is not None:
+            self._validate_lt(value, self.lt)
+
+        if self.ge is not None:
+            self._validate_ge(value, self.ge)
+
+        if self.le is not None:
+            self._validate_le(value, self.le)
+
+    def _validate_gt(
+        self,
+        value: Union[int, float, complex, Decimal],
+        limit: Union[int, float, complex, Decimal]
+    ):
+        if not value > limit:
+            raise ValueError(
+                self.ERROR_MSGS["gt"].format(
+                    attr_name=self.public_attr_name,
+                    value=value,
+                    limit=limit
+                )
+            )
+
+    def _validate_lt(
+        self,
+        value: Union[int, float, complex, Decimal],
+        limit: Union[int, float, complex, Decimal]
+    ):
+        if not value < limit:
+            raise ValueError(
+                self.ERROR_MSGS["lt"].format(
+                    attr_name=self.public_attr_name,
+                    value=value,
+                    limit=limit
+                )
+            )
+
+    def _validate_ge(
+        self,
+        value: Union[int, float, complex, Decimal],
+        limit: Union[int, float, complex, Decimal]
+    ):
+        if not value >= limit:
+            raise ValueError(
+                self.ERROR_MSGS["ge"].format(
+                    attr_name=self.public_attr_name,
+                    value=value,
+                    limit=limit
+                )
+            )
+
+    def _validate_le(
+        self,
+        value: Union[int, float, complex, Decimal],
+        limit: Union[int, float, complex, Decimal]
+    ):
+        if not value <= limit:
+            raise ValueError(
+                self.ERROR_MSGS["le"].format(
+                    attr_name=self.public_attr_name,
+                    value=value,
+                    limit=limit
+                )
+            )
+
+
+class IntField(NumberField):
+    TYPE = int
+
+
+class FloatField(NumberField):
+    TYPE = float
+
+
+class DecimalField(NumberField):
+    TYPE = Decimal
+
+
+class ComplexField(NumberField):
+    """Complex numbers cannot be compared."""
+
+    TYPE = complex
+
+    def __init__(
+        self,
+        default: Optional[complex] = cast(complex, MISSING),
+        optional: bool=False,
+        use_private_attr: bool=False
+    ):
+        super().__init__(
+            default=default,
+            optional=optional,
+            use_private_attr=use_private_attr
+        )

--- a/dcv/fields/number.py
+++ b/dcv/fields/number.py
@@ -1,0 +1,33 @@
+from typing import Optional, Union, cast
+from decimal import Decimal
+from dcv.fields import Field, MISSING
+
+class NumberField(Field):
+    """Field validation for number values."""
+    ERROR_MSGS = {
+        "nan": "'{attr_name}' value '{value}' is not a number.",
+        "min": "'{attr_name}' value '{value}' cannot be less than {min}.",
+        "max": "'{attr_name}' value '{value}' cannot be more than {max}.",
+    }
+    TYPE = (int, float, complex, Decimal)
+
+    def __init__(
+        self,
+        default: Union[int, float, complex, Decimal, None] = cast(int, MISSING),
+        optional: bool=False,
+        use_private_attr: bool=False,
+        max_limit: Union[int, float, complex, Decimal, None] = None,
+        min_limit: Union[int, float, complex, Decimal, None] = None
+    ):
+        super().__init__(
+            default=default,
+            optional=optional,
+            use_private_attr=use_private_attr
+        )
+        self.max_limit = max_limit
+        self.min_limit = min_limit
+
+    def validate(self, value: Union[int, float, complex, Decimal, None]) -> None:
+        self._validate_optional(value)
+
+        self._check_type(value)

--- a/dcv/fields/text.py
+++ b/dcv/fields/text.py
@@ -7,7 +7,6 @@ class TextField(Field):
     ERROR_MSGS = {
         "max_length": "'{attr_name}' length cannot be more than {length}.",
         "min_length": "'{attr_name}' length cannot be less than {length}.",
-        "optional": "'{attr_name}' must contain a value.",
         "blank": "'{attr_name}' cannot be blank.",
         "regex": "'{attr_name}' does not match regex: {regex} .",
     }

--- a/t/unit/test_number.py
+++ b/t/unit/test_number.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Union
 import pytest
-from dcv.fields.number import NumberField
+from dcv.fields.number import NumberField, ComplexField
 
 def test_numbers():
     """Test all number types.
@@ -13,22 +13,26 @@ def test_numbers():
     """
     @dataclass
     class T:
+        co_num: complex = ComplexField()
         num: Union[int, float, complex, Decimal] = NumberField()
+        second_co_num: complex = field(default=ComplexField())
         second_num: Union[int, float, complex, Decimal] = field(default=NumberField())
 
-    t = T(num=1, second_num=1)
+    t = T(num=1, second_num=1, co_num=1+2j, second_co_num=1+2j)
     assert t.num == 1
     assert t.second_num == 1
+    assert t.co_num == 1+2j
+    assert t.second_co_num == 1+2j
 
-    t = T(num=1.0, second_num=1.0)
+    t = T(num=1.0, second_num=1.0, co_num=1+2j, second_co_num=1+2j)
     assert t.num == 1.0
     assert t.second_num == 1.0
 
-    t = T(num=complex("1+2j"), second_num=1+2j)
+    t = T(num=complex("1+2j"), second_num=1+2j, co_num=1+2j, second_co_num=1+2j)
     assert t.num == 1+2j
     assert t.second_num == 1+2j
 
-    t = T(num=Decimal("1.0"), second_num=Decimal(1.0))
+    t = T(num=Decimal("1.0"), second_num=Decimal(1.0), co_num=1+2j, second_co_num=1+2j)
     assert t.num == Decimal("1.0")
     assert t.second_num == Decimal("1.0")
 
@@ -40,3 +44,183 @@ def test_numbers():
 
     with pytest.raises(TypeError):
         T(num=[])
+
+
+def test_lt():
+    """Test less than.
+
+    GIVEN a dataclass with a `Union[int, float, complex, Decimal]` field and a
+        validator with a lt
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class TInt:
+        num: Union[int, float, complex, Decimal] = NumberField(lt=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(lt=3))
+
+    @dataclass
+    class TFloat:
+        num: Union[int, float, complex, Decimal] = NumberField(lt=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(lt=3))
+
+    @dataclass
+    class TDecimal:
+        num: Union[int, float, complex, Decimal] = NumberField(lt=Decimal(3.0))
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(lt=3))
+
+    t_int = TInt(num=1, second_num=1)
+    assert t_int.num == 1
+    assert t_int.second_num == 1
+
+    t_float = TFloat(num=1.0, second_num=1.0)
+    assert t_float.num == 1.0
+    assert t_float.second_num == 1.0
+
+    t_dec = TDecimal(num=Decimal(1.0), second_num=Decimal(1.0))
+    assert t_dec.num == 1
+    assert t_dec.second_num == 1
+
+    with pytest.raises(ValueError):
+        TInt(num=4)
+
+    with pytest.raises(ValueError):
+        TFloat(second_num=3.1, num=3.1)
+
+    with pytest.raises(ValueError):
+        TDecimal(second_num=Decimal(3.1), num=3.1)
+
+
+def test_gt():
+    """Test gt.
+
+    GIVEN a dataclass with a `Union[int, float, complex, Decimal]` field and a
+        validator with a max limit
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class TInt:
+        num: Union[int, float, complex, Decimal] = NumberField(gt=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(gt=3))
+
+    @dataclass
+    class TFloat:
+        num: Union[int, float, complex, Decimal] = NumberField(gt=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(gt=3))
+
+    @dataclass
+    class TDecimal:
+        num: Union[int, float, complex, Decimal] = NumberField(gt=Decimal(3.0))
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(gt=3))
+
+    t_int = TInt(num=4, second_num=4)
+    assert t_int.num == 4 
+    assert t_int.second_num == 4
+
+    t_float = TFloat(num=3.1, second_num=3.1)
+    assert t_float.num == 3.1
+    assert t_float.second_num == 3.1
+
+    t_dec = TDecimal(num=Decimal(3.1), second_num=Decimal(3.1))
+    assert t_dec.num == 3.1
+    assert t_dec.second_num == 3.1
+
+    with pytest.raises(ValueError):
+        TInt(num=3)
+
+    with pytest.raises(ValueError):
+        TFloat(second_num=3.0, num=3.0)
+
+    with pytest.raises(ValueError):
+        TDecimal(second_num=Decimal(3.0), num=3.0)
+
+
+def test_le():
+    """Test less than or equal.
+
+    GIVEN a dataclass with a `Union[int, float, complex, Decimal]` field and a
+        validator with le
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class TInt:
+        num: Union[int, float, complex, Decimal] = NumberField(le=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    @dataclass
+    class TFloat:
+        num: Union[int, float, complex, Decimal] = NumberField(le=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    @dataclass
+    class TDecimal:
+        num: Union[int, float, complex, Decimal] = NumberField(le=Decimal(3.0))
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    t_int = TInt(num=3, second_num=2)
+    assert t_int.num == 3 
+    assert t_int.second_num == 2
+
+    t_float = TFloat(num=2.9, second_num=3.0)
+    assert t_float.num == 2.9
+    assert t_float.second_num == 3.0
+
+    t_dec = TDecimal(num=Decimal(2.9), second_num=Decimal(3.0))
+    assert t_dec.num == 2.9
+    assert t_dec.second_num == 3.0
+
+    with pytest.raises(ValueError):
+        TInt(num=4)
+
+    with pytest.raises(ValueError):
+        TFloat(second_num=3.1, num=3.0)
+
+    with pytest.raises(ValueError):
+        TDecimal(second_num=Decimal(3.0), num=3.1)
+
+
+def test_le():
+    """Test less than or equal.
+
+    GIVEN a dataclass with a `Union[int, float, complex, Decimal]` field and a
+        validator with le
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class TInt:
+        num: Union[int, float, complex, Decimal] = NumberField(le=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    @dataclass
+    class TFloat:
+        num: Union[int, float, complex, Decimal] = NumberField(le=3)
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    @dataclass
+    class TDecimal:
+        num: Union[int, float, complex, Decimal] = NumberField(le=Decimal(3.0))
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField(le=3))
+
+    t_int = TInt(num=3, second_num=2)
+    assert t_int.num == 3 
+    assert t_int.second_num == 2
+
+    t_float = TFloat(num=2.9, second_num=3.0)
+    assert t_float.num == 2.9
+    assert t_float.second_num == 3.0
+
+    t_dec = TDecimal(num=Decimal(2.9), second_num=Decimal(3.0))
+    assert t_dec.num == 2.9
+    assert t_dec.second_num == 3.0
+
+    with pytest.raises(ValueError):
+        TInt(num=4)
+
+    with pytest.raises(ValueError):
+        TFloat(second_num=3.1, num=3.0)
+
+    with pytest.raises(ValueError):
+        TDecimal(second_num=Decimal(3.0), num=3.1)

--- a/t/unit/test_number.py
+++ b/t/unit/test_number.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Union
+import pytest
+from dcv.fields.number import NumberField
+
+def test_numbers():
+    """Test all number types.
+
+    GIVEN a dataclass with a `Union[int, float, complex, Decimal]` field
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class T:
+        num: Union[int, float, complex, Decimal] = NumberField()
+        second_num: Union[int, float, complex, Decimal] = field(default=NumberField())
+
+    t = T(num=1, second_num=1)
+    assert t.num == 1
+    assert t.second_num == 1
+
+    t = T(num=1.0, second_num=1.0)
+    assert t.num == 1.0
+    assert t.second_num == 1.0
+
+    t = T(num=complex("1+2j"), second_num=1+2j)
+    assert t.num == 1+2j
+    assert t.second_num == 1+2j
+
+    t = T(num=Decimal("1.0"), second_num=Decimal(1.0))
+    assert t.num == Decimal("1.0")
+    assert t.second_num == Decimal("1.0")
+
+    with pytest.raises(TypeError):
+        T(num="asdf")
+
+    with pytest.raises(TypeError):
+        T(second_num={})
+
+    with pytest.raises(TypeError):
+        T(num=[])


### PR DESCRIPTION
[feature: number fields] closes #9

Add int, float, decimal and complex fields.

All number fields inherit from `dcv.fields.NumberField`.
Except for `ComplexField` every other number field accepts `lt`, `gt`, `le` and `ge` limits.