### PR TITLE
[#15] Add date time fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ logging.basicConfig(level=logging.INFO)
 @dataclass
 class User:
     # trailing/leading blank spaces will be removed
-    name: str = TextField(min_length=1, trim=" ")
+    name: str = TextField(min_length=1, trim=True)
 
     # 'last_name' can be None or an empty string.
     # Optional fields have a default value of None.
@@ -120,19 +120,61 @@ checked against the objects in the `Field.TYPES` tuple.
 
 ## Available Fields
 
-| Name          | Types Supported                        | Implemented            | Parent Field | 
-|---------------|----------------------------------------|------------------------|--------------|
-| `TextField`   | `str`, `bytes`                         | :heavy_check_mark: Yes | `Field`      |
-| `NumberField` | `int`, `float`, `complex`, `Decimal`   | :heavy_check_mark: Yes | `Field`      |
-| `IntField`    | `int`                                  | :heavy_check_mark: Yes | `NumberField`|
-| `FloatField`  | `float`                                | :heavy_check_mark: Yes | `NumberField`|
-| `ComplexField`| `complex`                              | :heavy_check_mark: Yes | `NumberField`|
-| `DecimalField`| `Decimal`                              | :heavy_check_mark: Yes | `NumberField`|
-| `EnumField`   | `Enum`                                 | :heavy_check_mark: Yes | `Field`      |
-| `BooleanField`| `bool`                                 | :x: No                 |              |
-| `ListField`   | `list`, `tuple`                        | :x: No                 |              |
-| `SetField`    | `set`                                  | :x: No                 |              |
-| `DictField`   | `dict`                                 | :x: No                 |              |
+| Name               | Types Supported                        | Implemented            | Parent Field       | 
+|--------------------|----------------------------------------|------------------------|--------------------|
+| `TextField`        | `str`, `bytes`                         | :heavy_check_mark: Yes | `Field`            |
+| `NumberField`      | `int`, `float`, `complex`, `Decimal`   | :heavy_check_mark: Yes | `Field`            |
+| `IntField`         | `int`                                  | :heavy_check_mark: Yes | `NumberField`      |
+| `FloatField`       | `float`                                | :heavy_check_mark: Yes | `NumberField`      |
+| `ComplexField`     | `complex`                              | :heavy_check_mark: Yes | `NumberField`      |
+| `DecimalField`     | `Decimal`                              | :heavy_check_mark: Yes | `NumberField`      |
+| `EnumField`        | `Enum`                                 | :heavy_check_mark: Yes | `Field`            |
+| `BooleanField`     | `bool`                                 | :heavy_check_mark: Yes | `Field`            |
+| `DateTimeBaseField`| `date`, `time`, `datetime`, `timedelta`| :heavy_check_mark: Yes | `Field`            |
+| `DateField`        | `date`                                 | :heavy_check_mark: Yes | `DateTimeBaseField`|
+| `TimeField`        | `time`                                 | :heavy_check_mark: Yes | `DateTimeBaseField`|
+| `DateTimeField`    | `datetime`                             | :heavy_check_mark: Yes | `DateTimeBaseField`|
+| `TimeDeltaField`   | `timedelta`                            | :heavy_check_mark: Yes | `DateTimeBaseField`|
+| `ContianerField`   | `collections.abc.Container`            | :x: No                 |                    |
+| `SequenceField`    | `collections.abc.Sequence`             | :x: No                 |                    |
+| `SetField`         | `collections.abc.Set`                  | :x: No                 |                    |
+| `MappingField`     | `collections.abc.Mapping`              | :x: No                 |                    |
+
+## Custom Fields
+
+#### Subclassing existing field
+
+Custom fields can be created by subclassing any of the existing ones. This is recommended when you want to
+have the same functionality but check for another specific value type.
+
+For instance, you might want to validate a date field but you want to use another library and not python's
+`datetime`:
+
+```python
+
+from dcv.fields import DateTimeField
+from arrow import arrow
+
+class ArrowDTField(DateTimeField):
+    TYPES = (arrow.Arrow,)
+```
+
+#### Subclassing abstract `Field`
+
+You can also subclass the `Field` abstract class which already implements everything a field validation descriptor
+needs. The only required method to implement is `validate` which accepts the value being set:
+
+```python
+from dcv.fields.abstract import Field
+from app.models import User
+
+class UserField(Field):
+    TYPES = (User,)
+
+    def validate(self, value: User) -> None:
+        validate_user(value)
+
+```
 
 ## Future Work
 

--- a/dcv/fields/__init__.py
+++ b/dcv/fields/__init__.py
@@ -1,17 +1,37 @@
 from dcv.fields.abstract import Field, MISSING
 from dcv.fields.text import TextField
-from dcv.fields.number import IntField, FloatField, DecimalField, ComplexField
+from dcv.fields.number import (
+    NumberField,
+    IntField,
+    FloatField,
+    DecimalField,
+    ComplexField
+)
 from dcv.fields.enum import EnumField
 from dcv.fields.bool import BoolField
+from dcv.fields.datetime import (
+    DateTimeBaseField,
+    DateTimeField,
+    TimeDeltaField,
+    DateField,
+    TimeField
+)
+
 
 __all__ = [
     "MISSING",
     "Field",
     "TextField",
+    "NumberField",
     "IntField",
     "FloatField",
     "DecimalField",
     "ComplexField",
     "EnumField",
     "BoolField",
+    "DateTimeBaseField",
+    "DateTimeField",
+    "TimeDeltaField",
+    "DateField",
+    "TimeField"
 ]

--- a/dcv/fields/abstract.py
+++ b/dcv/fields/abstract.py
@@ -20,6 +20,8 @@ class Field(ABC):
     `default` is set to `None`.
 
     If `default` is set, `optional` is automatically set to `True`.
+
+    `TYPES` should always be a tuple of valid object types and not generics.
     """
     __slots__ = (
         'optional', 'use_private_attr', 'default',
@@ -196,14 +198,19 @@ class Field(ABC):
         origin = get_origin(type_hint)
         hint_arguments = get_args(type_hint)
 
+        # Could be a valid type, check if it is part of the valid types for this field
+        # or a sublcass of a valid type.
         if (origin is None and
             (type_hint in self.TYPES or
              any([issubclass(type_hint, valid_type) for valid_type in self.TYPES]))):
             return type_hint
 
+        # type_hint might be a generic that resolves to a valid type, e.g. List => list
         elif origin is not None and origin in self.TYPES:
             return origin
 
+        # If type_hint is not a valid type then recurse over the arguments.
+        # The valid types would be the arguments.
         elif type(origin) is not type and any(
             [
                 self._check_typehint_match_field_types(valid_type, hint_arguments)

--- a/dcv/fields/datetime.py
+++ b/dcv/fields/datetime.py
@@ -43,7 +43,7 @@ class DateTimeBaseField(Field):
             self._validate_gt(value, self.gt)
 
         if self.lt is not None:
-            self._validate_ge(value, self.lt)
+            self._validate_lt(value, self.lt)
 
         if self.ge is not None:
             self._validate_ge(value, self.ge)

--- a/dcv/fields/text.py
+++ b/dcv/fields/text.py
@@ -1,5 +1,5 @@
 from dcv.fields import Field, MISSING
-from typing import Optional, cast
+from typing import Optional, Union, cast
 import re
 
 class TextField(Field):
@@ -22,8 +22,8 @@ class TextField(Field):
         max_length: Optional[int]=None,
         min_length: Optional[int]=None, *,
         blank: bool=False,
-        regex: str=None,
-        trim: str=None
+        regex: Optional[str]=None,
+        trim: Union[str, bool]=False
     ):
         super().__init__(
             default=default,
@@ -56,7 +56,9 @@ class TextField(Field):
             self._validate_regex(value)
 
     def transform(self, value: str) -> str:
-        if self.trim is not None:
+        if self.trim is True:
+            return value.strip()
+        elif isinstance(self.trim, str):
             return value.strip(self.trim)
 
         return value

--- a/t/unit/test_datetime.py
+++ b/t/unit/test_datetime.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, date, time
 from typing import Union
 import pytest
-from dcv.fields.datetime import (
+from dcv.fields import (
     DateTimeField, TimeDeltaField,
     TimeField, DateField
 )
@@ -87,6 +87,213 @@ def test_datetime_gt():
     invalid_da: date = date(2020,1,1)
     valid_ti: time = time(hour=2)
     invalid_ti: time = time(hour=0,minute=50)
+
+    t = T(
+        date_time=valid_dt,
+        time_delta=valid_td,
+        date_val=valid_da,
+        time_val=valid_ti
+    )
+    
+    assert t.date_time == valid_dt
+    assert t.time_delta == valid_td
+    assert t.date_val == valid_da
+    assert t.time_val == valid_ti
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=invalid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=invalid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=invalid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=invalid_ti
+        )
+
+
+def test_datetime_lt():
+    """Test datetime fields lt
+
+    GTIVEN a dataclass with a date time field
+    WHEN a `lt` limit is set
+    THEN any value that's set should be validated correctly
+    """
+    @dataclass
+    class T:
+        date_time: datetime = DateTimeField(lt=datetime(2021,1,1))
+        time_delta: timedelta = TimeDeltaField(lt=timedelta(hours=1))
+        date_val: date = DateField(lt=date(2021,1,1))
+        time_val: time = TimeField(lt=time(hour=1))
+
+    valid_dt: datetime = datetime(2020, 2, 2)
+    invalid_dt: datetime = datetime(2021, 1, 2)
+    valid_td: timedelta = timedelta(minutes=50)
+    invalid_td: timedelta = timedelta(hours=2)
+    valid_da: date = date(2020,2,2)
+    invalid_da: date = date(2021,1,1)
+    valid_ti: time = time(hour=0, minute=50)
+    invalid_ti: time = time(hour=2)
+
+    t = T(
+        date_time=valid_dt,
+        time_delta=valid_td,
+        date_val=valid_da,
+        time_val=valid_ti
+    )
+    
+    assert t.date_time == valid_dt
+    assert t.time_delta == valid_td
+    assert t.date_val == valid_da
+    assert t.time_val == valid_ti
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=invalid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=invalid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=invalid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=invalid_ti
+        )
+
+
+def test_datetime_ge():
+    """Test datetime fields ge
+
+    GTIVEN a dataclass with a date time field
+    WHEN a `ge` limit is set
+    THEN any value that's set should be validated correctly
+    """
+    @dataclass
+    class T:
+        date_time: datetime = DateTimeField(ge=datetime(2021,1,1))
+        time_delta: timedelta = TimeDeltaField(ge=timedelta(hours=1))
+        date_val: date = DateField(ge=date(2021,1,1))
+        time_val: time = TimeField(ge=time(hour=1))
+
+    valid_dt: datetime = datetime(2021, 1, 1)
+    invalid_dt: datetime = datetime(2020, 1, 1)
+    valid_td: timedelta = timedelta(hours=1)
+    invalid_td: timedelta = timedelta(minutes=50)
+    valid_da: date = date(2021,1,1)
+    invalid_da: date = date(2020,1,1)
+    valid_ti: time = time(hour=1)
+    invalid_ti: time = time(hour=0,minute=50)
+
+    t = T(
+        date_time=valid_dt,
+        time_delta=valid_td,
+        date_val=valid_da,
+        time_val=valid_ti
+    )
+    
+    assert t.date_time == valid_dt
+    assert t.time_delta == valid_td
+    assert t.date_val == valid_da
+    assert t.time_val == valid_ti
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=invalid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=invalid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=invalid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=invalid_ti
+        )
+
+
+def test_datetime_le():
+    """Test datetime fields le
+
+    GTIVEN a dataclass with a date time field
+    WHEN a `le` limit is set
+    THEN any value that's set should be validated correctly
+    """
+    @dataclass
+    class T:
+        date_time: datetime = DateTimeField(le=datetime(2021,1,1))
+        time_delta: timedelta = TimeDeltaField(le=timedelta(hours=1))
+        date_val: date = DateField(le=date(2021,1,1))
+        time_val: time = TimeField(le=time(hour=1))
+
+    valid_dt: datetime = datetime(2020, 1, 1)
+    invalid_dt: datetime = datetime(2021, 1, 2)
+    valid_td: timedelta = timedelta(hours=1)
+    invalid_td: timedelta = timedelta(hours=2)
+    valid_da: date = date(2020,1,1)
+    invalid_da: date = date(2021,1,2)
+    valid_ti: time = time(hour=1)
+    invalid_ti: time = time(hour=2)
 
     t = T(
         date_time=valid_dt,

--- a/t/unit/test_datetime.py
+++ b/t/unit/test_datetime.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, date, time
+from typing import Union
+import pytest
+from dcv.fields.datetime import (
+    DateTimeField, TimeDeltaField,
+    TimeField, DateField
+)
+
+
+def test_base_datetime():
+    """Test DateTimeBaseField
+
+    GIVEN a dataclass with a `Union[datetime, timedelta, date, time]` field
+    WHEN a valid value is given
+    THEN it should validate the input on init.
+    """
+    @dataclass
+    class T:
+        date_time: datetime = DateTimeField()
+        time_delta: timedelta = TimeDeltaField()
+        date_val: date = DateField()
+        time_val: time = TimeField()
+
+    date_time: datetime = datetime(2021, 1, 1, 1, 1, 1)
+    time_delta: timedelta = timedelta(days=1)
+    date_val: date = date(2021,1,1)
+    time_val: time = time(2)
+    t = T(
+        date_time=date_time,
+        time_delta=time_delta,
+        date_val=date_val,
+        time_val=time_val
+    )
+    assert t.date_time == date_time
+    assert t.time_delta == time_delta
+    assert t.date_val == date_val
+    assert t.time_val == time_val
+
+    with pytest.raises(TypeError):
+        t = T(date_time='asdf',
+              time_delta=time_delta,
+              date_val=date_val,
+              time_val=time_val
+        )
+
+    with pytest.raises(TypeError):
+        t = T(date_time=date_time,
+              time_delta='asdf',
+              date_val=date_val,
+              time_val=time_val
+        )
+
+    with pytest.raises(TypeError):
+        t = T(date_time=date_time,
+              time_delta=time_delta,
+              date_val='asdf',
+              time_val=time_val
+        )
+
+    with pytest.raises(TypeError):
+        t = T(date_time=date_time,
+              time_delta=time_delta,
+              date_val=date_val,
+              time_val='asdf'
+        )
+
+def test_datetime_gt():
+    """Test datetime fields gt
+
+    GTIVEN a dataclass with a date time field
+    WHEN a `gt` limit is set
+    THEN any value that's set should be validated correctly
+    """
+    @dataclass
+    class T:
+        date_time: datetime = DateTimeField(gt=datetime(2021,1,1))
+        time_delta: timedelta = TimeDeltaField(gt=timedelta(hours=1))
+        date_val: date = DateField(gt=date(2021,1,1))
+        time_val: time = TimeField(gt=time(hour=1))
+
+    valid_dt: datetime = datetime(2021, 2, 2)
+    invalid_dt: datetime = datetime(2020, 1, 1)
+    valid_td: timedelta = timedelta(hours=2)
+    invalid_td: timedelta = timedelta(minutes=50)
+    valid_da: date = date(2021,2,2)
+    invalid_da: date = date(2020,1,1)
+    valid_ti: time = time(hour=2)
+    invalid_ti: time = time(hour=0,minute=50)
+
+    t = T(
+        date_time=valid_dt,
+        time_delta=valid_td,
+        date_val=valid_da,
+        time_val=valid_ti
+    )
+    
+    assert t.date_time == valid_dt
+    assert t.time_delta == valid_td
+    assert t.date_val == valid_da
+    assert t.time_val == valid_ti
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=invalid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=invalid_td,
+            date_val=valid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=invalid_da,
+            time_val=valid_ti
+        )
+
+    with pytest.raises(ValueError):
+        t = T(
+            date_time=valid_dt,
+            time_delta=valid_td,
+            date_val=valid_da,
+            time_val=invalid_ti
+        )

--- a/t/unit/test_number.py
+++ b/t/unit/test_number.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Union
 import pytest
-from dcv.fields.number import NumberField, ComplexField
+from dcv.fields import NumberField, ComplexField
 
 def test_numbers():
     """Test all number types.

--- a/t/unit/test_text.py
+++ b/t/unit/test_text.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 import pytest
-from dcv.fields.text import TextField
+from dcv.fields import TextField
 
 def test_str():
     """Str and text fields.


### PR DESCRIPTION
[featuer: datetime field] closes #15

Datetime fields use python's `datetime` types.
Fields do not validate or do any transformation for timezones.